### PR TITLE
Fix cleanup of database resources.

### DIFF
--- a/CS5430/src/database/DatabaseAdmin.java
+++ b/CS5430/src/database/DatabaseAdmin.java
@@ -1167,6 +1167,8 @@ public class DatabaseAdmin {
 				e.printStackTrace();
 			}
 			status = -1;
+		} finally {
+			DBManager.closePreparedStatement(pstmt);
 		}
 		return status;
 	}

--- a/CS5430/src/database/SocialNetworkDatabaseBoards.java
+++ b/CS5430/src/database/SocialNetworkDatabaseBoards.java
@@ -246,6 +246,7 @@ public class SocialNetworkDatabaseBoards {
 		finally {
 			DBManager.closePreparedStatement(insertBoardPstmt);
 			DBManager.closeResultSet(idresult);
+			DBManager.closePreparedStatement(addAdminPstmt);
 			DBManager.trueAutoCommit(conn);
 		}
 		if (firstsuccess == 1 && secondsuccess && thirdsuccess == 1) {

--- a/CS5430/src/database/SocialNetworkDatabaseBoards.java
+++ b/CS5430/src/database/SocialNetworkDatabaseBoards.java
@@ -342,7 +342,7 @@ public class SocialNetworkDatabaseBoards {
 		try {
 			String getRegionPrivs, getRegionAdmins;
 			String role = DatabaseAdmin.getUserRole(conn, username);
-			
+
 			if (role.equals("admin") || role.equals("sa")) { // an admin
 				getRegionAdmins = "SELECT * FROM main.boardadmins WHERE username = ?";
 				pstmt = conn.prepareStatement(getRegionAdmins);
@@ -351,10 +351,6 @@ public class SocialNetworkDatabaseBoards {
 				while (privResult.next()) { // returns true if there is a result set.
 					boardlist += "print \t" + privResult.getString("bname") + ";";
 				}
-				privResult.close();
-				pstmt.close();
-				privResult = null;
-				pstmt = null;
 			}
 			else if (!role.equals("")) {
 				stmt = conn.createStatement();
@@ -391,9 +387,10 @@ public class SocialNetworkDatabaseBoards {
 			sqlex = true;
 		}
 		finally {
-			DBManager.closeStatement(stmt);
+			DBManager.closeResultSet(privResult);
 			DBManager.closePreparedStatement(pstmt);
 			DBManager.closeResultSet(boards);
+			DBManager.closeStatement(stmt);
 		}
 		if (boardlist.equals("print Boards:;print freeforall") && !sqlex) {
 			return boardlist;

--- a/CS5430/src/database/SocialNetworkDatabaseBoards.java
+++ b/CS5430/src/database/SocialNetworkDatabaseBoards.java
@@ -274,9 +274,7 @@ public class SocialNetworkDatabaseBoards {
 	 * Assumes the board already exists and is not 'freeforall' board
 	 */
 	public static Boolean authorizedGoToBoard(Connection conn, String username, String boardname) {
-		Statement stmt = null;
 		PreparedStatement pstmt = null;
-		ResultSet boards = null;
 		ResultSet privResult = null;
 		Boolean authorized = null;
 		try {
@@ -290,24 +288,14 @@ public class SocialNetworkDatabaseBoards {
 				pstmt.setString(2, username);
 				privResult = pstmt.executeQuery();
 				authorized = new Boolean(privResult.next());
-				privResult.close();
-				pstmt.close();
-				privResult = null;
-				pstmt = null;
 			}
 			else if (!role.equals("")) {
-				stmt = conn.createStatement();
-
-				getRegionPrivs = "SELECT privilege FROM " 
+				getRegionPrivs = "SELECT privilege FROM "
 					+ boardname + ".regionprivileges WHERE username = ?";
 				pstmt = conn.prepareStatement(getRegionPrivs);
 				pstmt.setString(1, username);
 				privResult = pstmt.executeQuery();
 				authorized = new Boolean(privResult.next());
-				privResult.close();
-				pstmt.close();
-				privResult = null;
-				pstmt = null;
 			}
 			else { //there was an sql exception when getting the role.
 				
@@ -318,9 +306,8 @@ public class SocialNetworkDatabaseBoards {
 			
 		}
 		finally {
-			DBManager.closeStatement(stmt);
+			DBManager.closeResultSet(privResult);
 			DBManager.closePreparedStatement(pstmt);
-			DBManager.closeResultSet(boards);
 		}
 		return authorized;
 	}

--- a/CS5430/src/database/SocialNetworkDatabasePosts.java
+++ b/CS5430/src/database/SocialNetworkDatabasePosts.java
@@ -684,6 +684,11 @@ public class SocialNetworkDatabasePosts {
 			sqlex = true;
 		} catch (UnsupportedEncodingException e) {
 			// This should not happen.
+		} finally {
+			DBManager.closeResultSet(postResult);
+			DBManager.closePreparedStatement(originalPost);
+			DBManager.closeResultSet(repliesResult);
+			DBManager.closePreparedStatement(replies);
 		}
 		if (postAndReplies.equals("") && !sqlex) {
 			return "print Error: Post does not exist. Refresh. If the problem persists, contact an admin.";

--- a/CS5430/src/database/SocialNetworkDatabasePosts.java
+++ b/CS5430/src/database/SocialNetworkDatabasePosts.java
@@ -707,6 +707,8 @@ public class SocialNetworkDatabasePosts {
 			status = pstmt.executeUpdate();
 		} catch (SQLException e) {
 			status = 0;
+		} finally {
+			DBManager.closePreparedStatement(pstmt);
 		}
 		return status;
 	}

--- a/CS5430/src/database/SocialNetworkDatabasePosts.java
+++ b/CS5430/src/database/SocialNetworkDatabasePosts.java
@@ -47,6 +47,7 @@ public class SocialNetworkDatabasePosts {
 			System.out.println(e.getSQLState());
 		}
 		finally {
+			DBManager.closeResultSet(postResult);
 			DBManager.closePreparedStatement(pstmt);
 		}
 		return postExists;


### PR DESCRIPTION
In several places in your codebase, `PreparedStatements` or `ResultsSets` are not closed (generally or in case of errors while executing queries). This pull request fixes several such usages, as identified by our automated detector [MUDetect](https://github.com/stg-tud/MUDetect/). We would very much appreciate your feedback on our patch. Thank you very much!